### PR TITLE
Remove reference to mpitest.c from the Open MPI + Netpipe template 

### DIFF
--- a/etc/templates/ubuntu_ompi_netpipe.def.tmpl
+++ b/etc/templates/ubuntu_ompi_netpipe.def.tmpl
@@ -1,9 +1,6 @@
 Bootstrap: docker
 From: ubuntu:disco
 
-%files
-    mpitest.c /opt
-
 %environment
     OMPI_DIR=/opt/ompi-OMPIVERSION
     export OMPI_DIR


### PR DESCRIPTION
Fixes #9 