### PR TITLE
Sympi config fix

### DIFF
--- a/etc/singularity.conf
+++ b/etc/singularity.conf
@@ -1,3 +1,4 @@
+master=https://github.com/sylabs/singularity.git
 3.0.0=https://github.com/sylabs/singularity/releases/download/v3.0.0/singularity-v3.0.0.tar.gz
 3.0.1=https://github.com/sylabs/singularity/releases/download/v3.0.1/singularity-3.0.1.tar.gz
 3.0.2=https://github.com/sylabs/singularity/releases/download/v3.0.2/singularity-3.0.2.tar.gz
@@ -10,3 +11,4 @@
 3.4.0=https://github.com/sylabs/singularity/releases/download/v3.4.0/singularity-3.4.0.tar.gz
 3.4.1=https://github.com/sylabs/singularity/releases/download/v3.4.1/singularity-3.4.1.tar.gz
 3.4.2=https://github.com/sylabs/singularity/releases/download/v3.4.2/singularity-3.4.2.tar.gz
+3.5.0=https://github.com/sylabs/singularity/releases/download/v3.5.0/singularity-3.5.0.tar.gz

--- a/internal/pkg/builder/builder.go
+++ b/internal/pkg/builder/builder.go
@@ -168,7 +168,7 @@ func (b *Builder) InstallOnHost(pkg *implem.Info, env *buildenv.Info, sysCfg *sy
 
 	res.Err = env.Unpack()
 	if res.Err != nil {
-		res.Err = fmt.Errorf("failed to unpack MPI: %s", res.Err)
+		res.Err = fmt.Errorf("failed to unpack %s: %s", pkg.ID, res.Err)
 		return res
 	}
 

--- a/internal/pkg/checker/checker.go
+++ b/internal/pkg/checker/checker.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	cmdTimeout     = 10
-	prereqBinaries = "wget gfortran gcc g++ make file"
+	prereqBinaries = "wget gfortran gcc g++ make file mksquashfs bzip2 newuidmap"
 )
 
 // CheckDefFile does some checking on a definition file to ensure it can be used

--- a/internal/pkg/container/container.go
+++ b/internal/pkg/container/container.go
@@ -118,6 +118,9 @@ func Create(container *Config, sysCfg *sys.Config) error {
 	if sy.IsSudoCmd("build", sysCfg) {
 		log.Printf("-> Running %s %s %s %s %s\n", sysCfg.SudoBin, sysCfg.SingularityBin, "build", container.Path, container.DefFile)
 		cmd = exec.CommandContext(ctx, sysCfg.SudoBin, sysCfg.SingularityBin, "build", container.Path, container.DefFile)
+	} else if sysCfg.Nopriv {
+		log.Printf("-> Running %s %s %s %s\n", sysCfg.SingularityBin, "build --fakeroot", container.Path, container.DefFile)
+		cmd = exec.CommandContext(ctx, sysCfg.SudoBin, sysCfg.SingularityBin, "build", "--fakeroot", container.Path, container.DefFile)
 	} else {
 		log.Printf("-> Running %s %s %s %s\n", sysCfg.SingularityBin, "build", container.Path, container.DefFile)
 		cmd = exec.CommandContext(ctx, sysCfg.SingularityBin, "build", container.Path, container.DefFile)

--- a/internal/pkg/launcher/launcher.go
+++ b/internal/pkg/launcher/launcher.go
@@ -117,7 +117,7 @@ func Load() (sys.Config, jm.JM, network.Info, error) {
 	val := kv.GetValue(sympiKVs, sy.NoPrivKey)
 	cfg.Nopriv = false
 	nopriv, err := strconv.ParseBool(val)
-	if err != nil && val != "" && nopriv {
+	if nopriv {
 		cfg.Nopriv = true
 	}
 	val = kv.GetValue(sympiKVs, sy.SudoCmdsKey)

--- a/internal/pkg/manifest/manifest.go
+++ b/internal/pkg/manifest/manifest.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019, Sylabs Inc. All rights reserved.
+// This software is licensed under a 3-clause BSD license. Please consult the
+// LICENSE.md file distributed with the sources of this project regarding your
+// rights to use or distribute this software.
+
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func Create(filepath string, entries []string) error {
+	f, err := os.Create(filepath)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %s", filepath, err)
+	}
+
+	_, err = f.WriteString(strings.Join(entries, " "))
+	if err != nil {
+		return fmt.Errorf("failed to write to %s: %s", filepath, err)
+	}
+
+	return nil
+}

--- a/internal/pkg/manifest/manifest.go
+++ b/internal/pkg/manifest/manifest.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 )
 
+// Create a new manifest
 func Create(filepath string, entries []string) error {
 	f, err := os.Create(filepath)
 	if err != nil {

--- a/internal/pkg/util/file/file.go
+++ b/internal/pkg/util/file/file.go
@@ -52,6 +52,15 @@ func FileExists(path string) bool {
 	return !info.IsDir()
 }
 
+// IsDir checks whether a path is pointing at a directory or not
+func IsDir(name string) bool {
+	info, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsDir()
+}
+
 // GetTarOpts returns the arguments to use with tar based on the format of the tarball
 func GetTarArgs(format string) string {
 	switch format {

--- a/pkg/experiments/experiments.go
+++ b/pkg/experiments/experiments.go
@@ -202,17 +202,22 @@ func Run(exp Config, sysCfg *sys.Config, syConfig *sy.MPIToolConfig) (bool, resu
 	log.Println("-> Build container in", exp.ContainerBuildEnv.BuildDir)
 	log.Println("-> Target Linux distribution in container:", exp.Container.Distro)
 	log.Println("-> Storing container in", exp.ContainerBuildEnv.InstallDir)
+	log.Println("-> Container full path: ", exp.Container.Path)
 	log.Println("-> MPI implementation:", myContainerMPICfg.Implem.ID)
 	log.Println("-> MPI version:", myContainerMPICfg.Implem.Version)
 	log.Println("-> MPI URL:", myContainerMPICfg.Implem.URL)
 
 	// Pull or build the image
 	if syConfig.BuildPrivilege {
-		execRes = createNewContainer(&myContainerMPICfg, exp, sysCfg, syConfig)
-		if execRes.Err != nil {
-			execRes.Err = fmt.Errorf("failed to create container: %s", err)
-			expRes.Pass = false
-			return false, expRes, execRes
+		if !util.PathExists(exp.Container.Path) {
+			execRes = createNewContainer(&myContainerMPICfg, exp, sysCfg, syConfig)
+			if execRes.Err != nil {
+				execRes.Err = fmt.Errorf("failed to create container: %s", err)
+				expRes.Pass = false
+				return false, expRes, execRes
+			}
+		} else {
+			log.Printf("%s already exists, skipping build\n", exp.Container.Path)
 		}
 	} else {
 		err = container.PullContainerImage(&myContainerMPICfg.Container, &myContainerMPICfg.Implem, sysCfg, syConfig)


### PR DESCRIPTION
Fix problems with some SyMPI & SyValidate configurations:
- enable installing Singularity from master
- properly deal with a workflow without siud
- make it easier to see the configuration when dealing with many MPIs, Singularity installations and containers
- do not create a container image when the image is already available