### PR TITLE
Fix problems when running applications that have been containerized

### DIFF
--- a/README.sycontainerize.md
+++ b/README.sycontainerize.md
@@ -14,8 +14,7 @@ versions of MPI, assuming your application is based on MPI.
 - `app_url` which is the URL where to fetch the source code of your application. The URL can be a http/https URL, a file (starting with `file://`), or the URL of a Git repository. The tool will figure out how to get the source ready from the URL.
 - `app_compile_cmd` which is the command to execute to compile your application, e.g., `make` or `mpicc -o myapp.exe myapp.c`.
 - `mpi_model` which is the string representing the MPI model to use. We currently support two models: `hybrid` and `bind`. For details about these two models, please refer to the Singularity User Documentation.
-- `mpi` which is the string representing the MPI implementation that you wish to use, i.e., at the moment `openmpi` or `mpich`.
-- `container_mpi` which is the version of the MPI implementation to be used with the application. If `mpi` is set to `openmpi` and `container_mpi` to 3.0.4, it means that openmpi-3.0.4 should be installed.
+- `mpi` which is the string representing the MPI implementation and its version that you wish to use, i.e., at the moment `openmpi:3.0.4` or `mpich:3.3`.
 - `distro` is the identifier of the target Linux distribution to be used in the container. Ubuntu Disco, CentOS 6 and CentOS 7 have been tested.
 - `registry` is the name of your target Sylabs' registry if you want the image to be automatically uploaded. Note that it requires you to be logged in the service and correctly setup your keyring. Please refer to the Singularity User Documentation for details. This entry is optional.
 
@@ -29,8 +28,7 @@ app_url = http://netpipe.cs.ksu.edu/download/NetPIPE-5.1.4.tar.gz
 app_exe = NPmpi
 app_compile_cmd = make mpi
 mpi_model = bind
-mpi = openmpi
-container_mpi = 4.0.2
+mpi = openmpi:4.0.2
 distro = ubuntu:disco
 ```
 

--- a/cmd/syvalidate/syvalidate.go
+++ b/cmd/syvalidate/syvalidate.go
@@ -305,6 +305,12 @@ func main() {
 		log.Fatalf("failed to load the tool's configuration: %s", err)
 	}
 
+	// Try to get more data about the configuration of Singularity
+	sysCfg, err = sy.LookupConfig(&sysCfg)
+	if err != nil {
+		log.Fatalf("failed to check configuration of Singularity")
+	}
+
 	// Figure out all the experiments that need to be executed
 	experiments := getListExperiments(config)
 	mpiImplem, err := exp.GetMPIImplemFromExperiments(experiments)

--- a/internal/pkg/builder/builder.go
+++ b/internal/pkg/builder/builder.go
@@ -144,6 +144,14 @@ func (b *Builder) install(pkg *implem.Info, env *buildenv.Info, sysCfg *sys.Conf
 func (b *Builder) InstallOnHost(pkg *implem.Info, env *buildenv.Info, sysCfg *sys.Config) syexec.Result {
 	var res syexec.Result
 
+	if env.InstallDir == "" {
+		fmt.Println("undefined install dir")
+	}
+
+	if pkg.URL == "" {
+		fmt.Println("undefined URL")
+	}
+
 	// Sanity checks
 	if env.InstallDir == "" || pkg.URL == "" {
 		res.Err = fmt.Errorf("invalid parameter(s)")
@@ -363,6 +371,7 @@ func (b *Builder) CompileAppOnHost(appInfo *app.Info, mpiCfg *mpi.Config, buildE
 
 	log.Printf("Build MPI in %s from %s\n", buildEnv.BuildDir, mpi.URL)
 	log.Printf("Install MPI in %s\n", buildEnv.InstallDir)
+	mpiCfg.Buildenv.InstallDir = buildEnv.InstallDir
 
 	if !util.PathExists(buildEnv.BuildDir) {
 		err := util.DirInit(buildEnv.BuildDir)
@@ -375,8 +384,6 @@ func (b *Builder) CompileAppOnHost(appInfo *app.Info, mpiCfg *mpi.Config, buildE
 	if res.Err != nil {
 		return fmt.Errorf("failed to install MPI on host: %s", res.Err)
 	}
-
-	mpiCfg.Buildenv.InstallDir = buildEnv.InstallDir
 
 	// Install the app on the host
 	buildEnv.BuildDir = filepath.Join(sysCfg.ScratchDir, appInfo.Name)

--- a/internal/pkg/builder/builder.go
+++ b/internal/pkg/builder/builder.go
@@ -144,14 +144,6 @@ func (b *Builder) install(pkg *implem.Info, env *buildenv.Info, sysCfg *sys.Conf
 func (b *Builder) InstallOnHost(pkg *implem.Info, env *buildenv.Info, sysCfg *sys.Config) syexec.Result {
 	var res syexec.Result
 
-	if env.InstallDir == "" {
-		fmt.Println("undefined install dir")
-	}
-
-	if pkg.URL == "" {
-		fmt.Println("undefined URL")
-	}
-
 	// Sanity checks
 	if env.InstallDir == "" || pkg.URL == "" {
 		res.Err = fmt.Errorf("invalid parameter(s)")

--- a/internal/pkg/deffile/deffile.go
+++ b/internal/pkg/deffile/deffile.go
@@ -104,7 +104,6 @@ func addLabels(f *os.File, app *app.Info, deffile *DefFileData) error {
 		return err
 	}
 
-	//deffile.InternalEnv.InstallDir = setMPIInstallDir(deffile.MpiImplm.ID, deffile.MpiImplm.Version)
 	_, err = f.WriteString("\tMPI_Directory " + deffile.InternalEnv.InstallDir + "\n")
 	if err != nil {
 		return err
@@ -305,8 +304,6 @@ func AddMPIInstall(f *os.File, deffile *DefFileData) error {
 
 // addMPIEnv adds all the data to the definition file to specify the environment of the MPI installation in the container
 func addMPIEnv(f *os.File, deffile *DefFileData) error {
-	//deffile.InternalEnv.InstallDir = setMPIInstallDir(deffile.MpiImplm.ID, deffile.MpiImplm.Version)
-
 	_, err := f.WriteString("%environment\n\tMPI_DIR=" + deffile.InternalEnv.InstallDir + "\n")
 	if err != nil {
 		return err

--- a/internal/pkg/mpi/mpi.go
+++ b/internal/pkg/mpi/mpi.go
@@ -58,7 +58,7 @@ func getBindArguments(hostMPI *implem.Info, hostBuildenv *buildenv.Info, c *cont
 
 // GetMpirunArgs returns the arguments required by a mpirun
 func GetMpirunArgs(myHostMPICfg *implem.Info, hostBuildEnv *buildenv.Info, app *app.Info, syContainer *container.Config, sysCfg *sys.Config) ([]string, error) {
-	args := []string{"singularity", "exec"}
+	args := []string{"singularity", "exec", "--cleanenv", "--contain", "--no-home", "--writable"}
 
 	if sysCfg.Nopriv {
 		args = append(args, "-u")

--- a/pkg/containizer/containerizer.go
+++ b/pkg/containizer/containerizer.go
@@ -152,7 +152,6 @@ func generateMPIDeffile(app *appConfig, mpiCfg *mpi.Config, sysCfg *sys.Config) 
 
 		// todo: should call the builder and not directly that function
 		deffileCfg.InternalEnv.InstallDir = mpiCfg.Buildenv.InstallDir
-		fmt.Printf("CHECKME: %s\n", deffileCfg.InternalEnv.InstallDir)
 		err = deffile.CreateBindDefFile(&app.info, &deffileCfg, sysCfg)
 		if err != nil {
 			return def, fmt.Errorf("unable to create container: %s", err)

--- a/pkg/experiments/experiments.go
+++ b/pkg/experiments/experiments.go
@@ -138,6 +138,7 @@ func Run(exp Config, sysCfg *sys.Config, syConfig *sy.MPIToolConfig) (bool, resu
 	myContainerMPICfg.Buildenv = exp.ContainerBuildEnv
 	myContainerMPICfg.Container.Name = container.GetContainerDefaultName(exp.Container.Distro, exp.ContainerMPI.ID, exp.ContainerMPI.Version, exp.App.Name, container.HybridModel) + ".sif"
 	myContainerMPICfg.Container.Path = filepath.Join(myContainerMPICfg.Buildenv.InstallDir, myContainerMPICfg.Container.Name)
+	exp.Container.Path = myContainerMPICfg.Container.Path
 	myContainerMPICfg.Container.Model = container.HybridModel
 	myContainerMPICfg.Container.URL = sy.GetImageURL(&myContainerMPICfg.Implem, sysCfg)
 	myContainerMPICfg.Container.BuildDir = myContainerMPICfg.Buildenv.BuildDir
@@ -208,7 +209,7 @@ func Run(exp Config, sysCfg *sys.Config, syConfig *sy.MPIToolConfig) (bool, resu
 	log.Println("-> MPI URL:", myContainerMPICfg.Implem.URL)
 
 	// Pull or build the image
-	if syConfig.BuildPrivilege {
+	if syConfig.BuildPrivilege || sysCfg.Nopriv {
 		if !util.PathExists(exp.Container.Path) {
 			execRes = createNewContainer(&myContainerMPICfg, exp, sysCfg, syConfig)
 			if execRes.Err != nil {


### PR DESCRIPTION
I ran into quite a bit of problems when creating a container with sycontainerize on a system and try to run it on a different system with sympi: the environment was not self-contained. These set of modifications fixes this. As a result, we changed the way we build and run containers.
As a side effect, I found an easy to figure out where the application binary is in the container. Not perfect but it seems to work.