### PR TITLE
Create manifests for Singularity installations

### DIFF
--- a/internal/pkg/manifest/manifest.go
+++ b/internal/pkg/manifest/manifest.go
@@ -6,10 +6,41 @@
 package manifest
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
+
+func getFileHash(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	hasher := sha256.New()
+	_, err = io.Copy(hasher, f)
+	if err != nil {
+		return ""
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// Hash files returns the hash for a list of files (absolute path)
+func HashFiles(files []string) []string {
+	var hashData []string
+
+	for _, file := range files {
+		hash := getFileHash(file)
+		hashData = append(hashData, file+": "+hash)
+	}
+
+	return hashData
+}
 
 // Create a new manifest
 func Create(filepath string, entries []string) error {

--- a/pkg/sympi/sympi.go
+++ b/pkg/sympi/sympi.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sylabs/singularity-mpi/internal/pkg/kv"
 	"github.com/sylabs/singularity-mpi/internal/pkg/launcher"
 	"github.com/sylabs/singularity-mpi/internal/pkg/mpi"
+	"github.com/sylabs/singularity-mpi/internal/pkg/sy"
 	"github.com/sylabs/singularity-mpi/internal/pkg/syexec"
 	"github.com/sylabs/singularity-mpi/internal/pkg/sys"
 	util "github.com/sylabs/singularity-mpi/internal/pkg/util/file"
@@ -275,8 +276,10 @@ func RunContainer(containerDesc string, args []string, sysCfg *sys.Config) error
 	}
 
 	// Inspect the image and extract the metadata
-	if sysCfg.SingularityBin == "" {
-		log.Fatalf("singularity bin not defined")
+	err = sy.CheckIntegrity(sysCfg)
+	if err != nil {
+		fmt.Printf("[WARNING] Your Singularity installation seems to be corrupted: %s\n", err)
+		return fmt.Errorf("Compromised Singularity installation")
 	}
 
 	fmt.Printf("Analyzing %s to figure out the correct configuration for execution...\n", imgPath)


### PR DESCRIPTION
Signed-off-by: Geoffroy Vallee <geoffroy.vallee@gmail.com>

Also checks the integrity of Singularity before using the binary: if the binary has a different sha256 hash that the one recorded, the installation is considered corrupted/compromised and therefore cannot be used.